### PR TITLE
Fix GitHub workflow Node.js error with deprecated --loader flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "version": "1.0.0",
     "type": "module",
     "scripts": {
-      "start": "node --loader ts-node/esm src/main.ts",
+      "start": "npm run build && node dist/main.js",
       "build": "tsc --project tsconfig.json",
-    "dev": "node --loader ts-node/esm src/main.ts",
+    "dev": "node --import=./register.mjs src/main.ts",
     "clean": "rm -rf docs/feeds/*.xml"
     },
     "dependencies": {

--- a/register.mjs
+++ b/register.mjs
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('ts-node/esm', pathToFileURL('./'));

--- a/src/NewsAggregator.ts
+++ b/src/NewsAggregator.ts
@@ -12,7 +12,6 @@ import { NextAppleEntertainmentSource } from './sources/NextAppleEntertainmentSo
 import { DailyMailTVShowbizSource } from './sources/DailyMailTVShowbizSource.js';
 import { PageSixEntertainmentSource } from './sources/PageSixEntertainmentSource.js';
 import { HK01EntertainmentSource } from './sources/HK01EntertainmentSource.js';
-import { CoinTelegraphCryptoSource } from './sources/CoinTelegraphCryptoSource.js';
 import { SosoValueSource } from './sources/SosoValueSource.js';
 import { TwitterRSSSource } from './sources/TwitterRSSSource.js';
 import { NewsItem, NewsCategory, ScrapingResult, SourceConfig } from './types/index.js';
@@ -85,9 +84,6 @@ export class NewsAggregator {
         }
         if (config.id === 'hk01-entertainment') {
           return new HK01EntertainmentSource(config);
-        }
-        if (config.id === 'cointelegraph-crypto') {
-          return new CoinTelegraphCryptoSource(config);
         }
         if (config.id === 'sosovalue-research') {
           return new SosoValueSource(config);

--- a/src/config/sources.json
+++ b/src/config/sources.json
@@ -190,25 +190,6 @@
       ]
     },
     {
-      "id": "cointelegraph-crypto",
-      "name": "CoinTelegraph Crypto News",
-      "type": "scraper",
-      "baseUrl": "https://cointelegraph.com",
-      "rateLimit": 5,
-      "enabled": true,
-      "headers": {
-        "User-Agent": "Mozilla/5.0 (compatible; NewsAggregator/1.0)"
-      },
-      "categories": [
-        {
-          "category": "crypto",
-          "endpoint": "/category/crypto",
-          "maxItems": 25,
-          "updateFrequency": 5
-        }
-      ]
-    },
-    {
       "id": "sosovalue-research",
       "name": "SosoValue Research",
       "type": "scraper", 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -15,6 +15,9 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
+  },
+  "ts-node": {
+    "esm": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
- Replace deprecated --loader ts-node/esm with build-first approach
- Add register.mjs for development ts-node ESM compatibility
- Remove missing CoinTelegraphCryptoSource references
- Update tsconfig.json for better ESM support
- Fixes Node.js 18.20.8 compatibility issues in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)